### PR TITLE
Replace the buggy next_migration_number implementation with what ActiveR...

### DIFF
--- a/lib/generators/letsrate/letsrate_generator.rb
+++ b/lib/generators/letsrate/letsrate_generator.rb
@@ -1,6 +1,6 @@
 require 'rails/generators/migration'
-require 'rails/generators/active_model'
-class LetsrateGenerator < Rails::Generators::NamedBase
+require 'rails/generators/active_record'
+class LetsrateGenerator < ActiveRecord::Generators::Base
   include Rails::Generators::Migration
   
   source_root File.expand_path('../templates', __FILE__)      
@@ -36,13 +36,5 @@ class LetsrateGenerator < Rails::Generators::NamedBase
   desc "migration is creating ..."
   def create_migration
     migration_template "migration.rb", "db/migrate/create_rates.rb"    
-  end   
-  
-  
-  private
-  # Implement the required interface for Rails::Generators::Migration.
-  def self.next_migration_number(dirname)
-    next_migration_number = current_migration_number(dirname) + 1
-    ActiveRecord::Migration.next_migration_number(next_migration_number)
   end
 end


### PR DESCRIPTION
...ecord::Generators::Base already have.

The current implementation of next_migration_number generates VERSION numbers that are too long. This results in these migrations been run last every time even if other migrations are created after these. Resulting in issues like : https://github.com/muratguzel/letsrate/issues/14

So just use what ActiveRecord::Generators::Base already have implemented.

https://github.com/rails/rails/blob/master/activerecord/lib/rails/generators/active_record.rb#L19
