### PR TITLE
Added option 'disable_after_rate' which makes the stars readOnly for the current user after successful rate

### DIFF
--- a/lib/generators/letsrate/templates/letsrate.js
+++ b/lib/generators/letsrate/templates/letsrate.js
@@ -1,27 +1,36 @@
-$.fn.raty.defaults.path = "/assets"; 
-$.fn.raty.defaults.half_show = true;  
- 
-$(function(){ 
-	$(".star").raty({			       
-		score: function(){
-			return $(this).attr('data-rating')				
-		}, 
-		number: function() {
-			return $(this).attr('data-star-count')
-		},
-		click: function(score, evt) {
-		   	$.post('<%= Rails.application.class.routes.url_helpers.rate_path %>', 
-				{
-					score: score, 
-					dimension: $(this).attr('data-dimension'),  
-					id: $(this).attr('data-id'),
-					klass: $(this).attr('data-classname')
-				}, 
-				function(data) {
-			  		if(data) {
-						// success code goes here ... 
-					}
-			});
-		}                        
-	});           
+$.fn.raty.defaults.path = "/assets";
+$.fn.raty.defaults.half_show = true;
+
+$(function(){
+  $(".star").each(function() {
+    var $readonly = ($(this).attr('data-readonly') == 'true');
+    $(this).raty({
+      score: function(){
+        return $(this).attr('data-rating')
+      },
+      number: function() {
+        return $(this).attr('data-star-count')
+      },
+      readOnly: $readonly,
+      click: function(score, evt) {
+        var _this = this;
+        $.post('<%= Rails.application.class.routes.url_helpers.rate_path %>',
+        {
+          score: score,
+          dimension: $(this).attr('data-dimension'),
+          id: $(this).attr('data-id'),
+          klass: $(this).attr('data-classname')
+        },
+        function(data) {
+          if(data) {
+            // success code goes here ...
+
+            if ($(_this).attr('data-disable-after-rate') == 'true') {
+              $(_this).raty('set', { readOnly: true, score: score });
+            }
+          }
+        });
+		  }
+    });
+	});
 });

--- a/lib/letsrate/helpers.rb
+++ b/lib/letsrate/helpers.rb
@@ -1,27 +1,34 @@
-module Helpers  
-  def rating_for(rateable_obj, dimension=nil, options={})                             
- 
+module Helpers
+  def rating_for(rateable_obj, dimension=nil, options={})
+
     if dimension.nil?
       klass = rateable_obj.average
-    else             
-      klass = rateable_obj.average "#{dimension}"    
+    else
+      klass = rateable_obj.average "#{dimension}"
     end
-    
+
     if klass.nil?
       avg = 0
     else
       avg = klass.avg
     end
-    
+
     star = options[:star] || 5
-    
-    content_tag :div, "", "data-dimension" => dimension, :class => "star", "data-rating" => avg, 
-                          "data-id" => rateable_obj.id, "data-classname" => rateable_obj.class.name,
-                          "data-star-count" => star           
-    
-    
+
+    disable_after_rate = options[:disable_after_rate] || false
+
+    readonly = false
+    if disable_after_rate
+      readonly = current_user.present? ? !rateable_obj.can_rate?(current_user.id, dimension) : true
+    end
+
+    content_tag :div, '', "data-dimension" => dimension, :class => "star", "data-rating" => avg,
+                "data-id" => rateable_obj.id, "data-classname" => rateable_obj.class.name,
+                "data-disable-after-rate" => disable_after_rate,
+                "data-readonly" => readonly,
+                "data-star-count" => star
   end
-     
+
 end
 
 class ActionView::Base


### PR DESCRIPTION
'disable_after_rate' may be set to true in the options param of the rating_for helper.
The stars become readonly after ajax rate and remain readonly after page refresh.
