### PR TITLE
Use symbols to create rating associations.

### DIFF
--- a/lib/letsrate/model.rb
+++ b/lib/letsrate/model.rb
@@ -82,14 +82,14 @@ module Letsrate
 
       dimensions.each do |dimension|        
         has_many :"#{dimension}_rates", :dependent => :destroy, 
-                                       :conditions => {:dimension => dimension.to_s}, 
-                                       :class_name => "Rate", 
-                                       :as => :rateable
+                                        :conditions => {:dimension => dimension.to_s}, 
+                                        :class_name => "Rate", 
+                                        :as => :rateable
                                        
         has_many :"#{dimension}_raters", :through => "#{dimension}_rates", :source => :rater         
         
         has_one :"#{dimension}_average", :as => :cacheable, :class_name => "RatingCache", 
-                                        :dependent => :destroy, :conditions => {:dimension => dimension.to_s}
+                                         :dependent => :destroy, :conditions => {:dimension => dimension.to_s}
       end                                                    
     end
   end


### PR DESCRIPTION
When using strings instead of symbols, joining queries with rating tables doesn't work. See http://stackoverflow.com/questions/16082485/how-can-i-sort-records-by-average-rating-with-latsrate-gem/16088821#16088821 for more information.
