### PR TITLE
create_migration method def changed to create_letsrate_migration to avoid collision with rails create_migration method name

### DIFF
--- a/lib/generators/letsrate/letsrate_generator.rb
+++ b/lib/generators/letsrate/letsrate_generator.rb
@@ -34,7 +34,7 @@ class LetsrateGenerator < ActiveRecord::Generators::Base
   end
 
   desc "migration is creating ..."
-  def create_migration
+  def create_letsrate_migration
     migration_template "migration.rb", "db/migrate/create_rates.rb"
   end
 end


### PR DESCRIPTION
create_migration method def changed to create_letsrate_migration to avoid collision with rails create_migration method name
/Users/jnaadjie/.rvm/gems/ruby-2.1.1@bleedingedge/gems/letsrate-1.0.9/lib/generators/letsrate/letsrate_generator.rb:37:in `create_migration': wrong number of arguments (3 for 0) (ArgumentError)
    from /Users/jnaadjie/.rvm/gems/ruby-2.1.1@global/gems/railties-4.1.0/lib/rails/generators/migration.rb:63:in`migration_template'
    from /Users/jnaadjie/.rvm/gems/ruby-2.1.1@bleedingedge/gems/letsrate-1.0.9/lib/generators/letsrate/letsrate_generator.rb:33:in `create_cacheable_migration'
    from /Users/jnaadjie/.rvm/gems/ruby-2.1.1@global/gems/thor-0.19.1/lib/thor/command.rb:27:in`run'
    from /Users/jnaadjie/.rvm/gems/ruby-2.1.1@global/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
    from /Users/jnaadjie/.rvm/gems/ruby-2.1.1@global/gems/thor-0.19.1/lib/thor/invocation.rb:133:in`block in invoke_all'
    from /Users/jnaadjie/.rvm/gems/ruby-2.1.1@global/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `each'
    from /Users/jnaadjie/.rvm/gems/ruby-2.1.1@global/gems/thor-0.19.1/lib/thor/invocation.rb:133:in`map'
    from /Users/jnaadjie/.rvm/gems/ruby-2.1.1@global/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `invoke_all'
    from /Users/jnaadjie/.rvm/gems/ruby-2.1.1@global/gems/thor-0.19.1/lib/thor/group.rb:232:in`dispatch'
    from /Users/jnaadjie/.rvm/gems/ruby-2.1.1@global/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
