### PR TITLE
Rating average cached in model

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,36 @@ class User < ActiveRecord::Base
 end
 ```
 
+### Caching
+
+Add the cache column/columns to the model (for rating with dimensions)
+```
+rails g migration AddRatingAveragesToCars
+```
+
+```ruby
+class AddRatingAveragesToCars < ActiveRecord::Migration
+  def change
+    add_column :cars, :speed_rating_average, :float, :default => 0
+    add_column :cars, :engine_rating_average, :float, :default => 0
+    add_column :cars, :price_rating_average, :float, :default => 0
+  end
+end
+```
+
+Add the cache column to the model (for rating without dimension)
+```
+rails g migration AddRatingAverageToCars
+```
+
+```ruby
+class AddRatingAverageToCars < ActiveRecord::Migration
+  def change
+    add_column :cars, :rating_average, :float, :default => 0
+  end
+end
+```
+
 ### Using
 
 There is a helper method which name is rating_for to add the star links. By default rating_for will display the average rating and accept the

--- a/lib/generators/letsrate/letsrate_generator.rb
+++ b/lib/generators/letsrate/letsrate_generator.rb
@@ -34,7 +34,7 @@ class LetsrateGenerator < ActiveRecord::Generators::Base
   end
 
   desc "migration is creating ..."
-  def create_migration
+  def create_rates_migration
     migration_template "migration.rb", "db/migrate/create_rates.rb"
   end
 end

--- a/lib/generators/letsrate/letsrate_generator.rb
+++ b/lib/generators/letsrate/letsrate_generator.rb
@@ -34,7 +34,7 @@ class LetsrateGenerator < ActiveRecord::Generators::Base
   end
 
   desc "migration is creating ..."
-  def create_rates_migration
+  def create_migration
     migration_template "migration.rb", "db/migrate/create_rates.rb"
   end
 end

--- a/lib/letsrate/helpers.rb
+++ b/lib/letsrate/helpers.rb
@@ -1,9 +1,10 @@
 module Helpers
   def rating_for(rateable_obj, dimension=nil, options={})
 
-    cached_average = rateable_obj.average dimension
+    cache_column_name = dimension ? "#{dimension}_rating_average" : "rating_average"
+    cached_average = rateable_obj.send(cache_column_name)
 
-    avg = cached_average ? cached_average.avg : 0
+    avg = cached_average ? cached_average : 0
 
     star = options[:star] || 5
 

--- a/lib/letsrate/model.rb
+++ b/lib/letsrate/model.rb
@@ -42,9 +42,13 @@ module Letsrate
       a.avg = davg
       a.save!(validate: false)
     end
+
+    cache_column_name = dimension ? "#{dimension}_rating_average" : "rating_average"
+    self.update_attribute cache_column_name.to_sym, davg
   end
 
   def update_rate_average(stars, dimension=nil)
+    cache_column_name = dimension ? "#{dimension}_rating_average" : "rating_average"
     if average(dimension).nil?
       RatingCache.create! do |avg|
         avg.cacheable_id = self.id
@@ -53,12 +57,14 @@ module Letsrate
         avg.qty = 1
         avg.dimension = dimension
       end
+      self.update_attribute cache_column_name.to_sym, stars
     else
       a = average(dimension)
       a.qty = rates(dimension).count
       a.avg = rates(dimension).average(:stars)
       a.save!(validate: false)
     end
+    self.update_attribute cache_column_name.to_sym, a.avg
   end
 
   def average(dimension=nil)


### PR DESCRIPTION
This will improve the performance when using rating_for helper.

Imagine that you want to show a list with many objects that are rateable, for each object letsrate had to make a query to the rating_cache database.

Simply adding an attribute to our rateable model we can easily store the average and reduce the queries, in consequence the performance will be improved.

Here there is a before/after example showing 5 objects

We can see that we passed from 11.8 ms to 3.3 ms (around 3 times faster)

```
10:27:58 web.1     | Started GET "/es/rutas/3" for 127.0.0.1 at 2015-03-01 10:27:58 +0100
10:27:58 web.1     | Processing by RoutesController#show as HTML
10:27:58 web.1     |   Parameters: {"locale"=>"es", "id"=>"3"}
10:27:58 web.1     |   Route Load (0.3ms)  SELECT  "routes".* FROM "routes"  WHERE "routes"."id" = $1 LIMIT 1  [["id", 3]]
10:27:58 web.1     |   Bar Load (0.5ms)  SELECT "bars".* FROM "bars"  WHERE "bars"."route_id" = $1  ORDER BY id DESC  [["route_id", 3]]
10:27:58 web.1     |   RatingCache Load (0.4ms)  SELECT  "rating_caches".* FROM "rating_caches"  WHERE "rating_caches"."cacheable_id" = $1 AND "rating_caches"."cacheable_type" = $2 AND "rating_caches"."dimension" = 'quality' LIMIT 1  [["cacheable_id", 15], ["cacheable_type", "Bar"]]
10:27:58 web.1     |   User Load (0.5ms)  SELECT  "users".* FROM "users"  WHERE "users"."id" = 1  ORDER BY "users"."id" ASC LIMIT 1
10:27:58 web.1     |    (0.4ms)  SELECT COUNT(*) FROM "rates"  WHERE "rates"."rater_id" = $1 AND "rates"."dimension" = 'quality' AND "rates"."rateable_id" = 15 AND "rates"."rateable_type" = 'Bar'  [["rater_id", 1]]
10:27:58 web.1     |   RatingCache Load (0.2ms)  SELECT  "rating_caches".* FROM "rating_caches"  WHERE "rating_caches"."cacheable_id" = $1 AND "rating_caches"."cacheable_type" = $2 AND "rating_caches"."dimension" = 'quality' LIMIT 1  [["cacheable_id", 14], ["cacheable_type", "Bar"]]
10:27:58 web.1     |    (0.2ms)  SELECT COUNT(*) FROM "rates"  WHERE "rates"."rater_id" = $1 AND "rates"."dimension" = 'quality' AND "rates"."rateable_id" = 14 AND "rates"."rateable_type" = 'Bar'  [["rater_id", 1]]
10:27:58 web.1     |   RatingCache Load (0.4ms)  SELECT  "rating_caches".* FROM "rating_caches"  WHERE "rating_caches"."cacheable_id" = $1 AND "rating_caches"."cacheable_type" = $2 AND "rating_caches"."dimension" = 'quality' LIMIT 1  [["cacheable_id", 13], ["cacheable_type", "Bar"]]
10:27:58 web.1     |    (0.2ms)  SELECT COUNT(*) FROM "rates"  WHERE "rates"."rater_id" = $1 AND "rates"."dimension" = 'quality' AND "rates"."rateable_id" = 13 AND "rates"."rateable_type" = 'Bar'  [["rater_id", 1]]
10:27:58 web.1     |   RatingCache Load (0.3ms)  SELECT  "rating_caches".* FROM "rating_caches"  WHERE "rating_caches"."cacheable_id" = $1 AND "rating_caches"."cacheable_type" = $2 AND "rating_caches"."dimension" = 'quality' LIMIT 1  [["cacheable_id", 12], ["cacheable_type", "Bar"]]
10:27:58 web.1     |    (0.3ms)  SELECT COUNT(*) FROM "rates"  WHERE "rates"."rater_id" = $1 AND "rates"."dimension" = 'quality' AND "rates"."rateable_id" = 12 AND "rates"."rateable_type" = 'Bar'  [["rater_id", 1]]
10:27:58 web.1     |   RatingCache Load (0.3ms)  SELECT  "rating_caches".* FROM "rating_caches"  WHERE "rating_caches"."cacheable_id" = $1 AND "rating_caches"."cacheable_type" = $2 AND "rating_caches"."dimension" = 'quality' LIMIT 1  [["cacheable_id", 11], ["cacheable_type", "Bar"]]
10:27:58 web.1     |    (0.2ms)  SELECT COUNT(*) FROM "rates"  WHERE "rates"."rater_id" = $1 AND "rates"."dimension" = 'quality' AND "rates"."rateable_id" = 11 AND "rates"."rateable_type" = 'Bar'  [["rater_id", 1]]
10:27:58 web.1     |   Rendered routes/show.html.erb within layouts/application (48.0ms)
10:27:58 web.1     | Completed 200 OK in 169ms (Views: 124.4ms | ActiveRecord: 11.9ms)




11:38:51 web.1     | Started GET "/es/rutas/3" for 127.0.0.1 at 2015-03-01 11:38:51 +0100
11:38:51 web.1     | Processing by RoutesController#show as HTML
11:38:51 web.1     |   Parameters: {"locale"=>"es", "id"=>"3"}
11:38:51 web.1     |   Route Load (0.3ms)  SELECT  "routes".* FROM "routes"  WHERE "routes"."id" = $1 LIMIT 1  [["id", 3]]
11:38:51 web.1     |   Bar Load (0.3ms)  SELECT "bars".* FROM "bars"  WHERE "bars"."route_id" = $1  ORDER BY id DESC  [["route_id", 3]]
11:38:51 web.1     |   User Load (0.3ms)  SELECT  "users".* FROM "users"  WHERE "users"."id" = 1  ORDER BY "users"."id" ASC LIMIT 1
11:38:51 web.1     |    (0.2ms)  SELECT COUNT(*) FROM "rates"  WHERE "rates"."rater_id" = $1 AND "rates"."dimension" = 'quality' AND "rates"."rateable_id" = 15 AND "rates"."rateable_type" = 'Bar'  [["rater_id", 1]]
11:38:51 web.1     |    (0.2ms)  SELECT COUNT(*) FROM "rates"  WHERE "rates"."rater_id" = $1 AND "rates"."dimension" = 'quality' AND "rates"."rateable_id" = 14 AND "rates"."rateable_type" = 'Bar'  [["rater_id", 1]]
11:38:51 web.1     |    (0.2ms)  SELECT COUNT(*) FROM "rates"  WHERE "rates"."rater_id" = $1 AND "rates"."dimension" = 'quality' AND "rates"."rateable_id" = 13 AND "rates"."rateable_type" = 'Bar'  [["rater_id", 1]]
11:38:51 web.1     |    (0.2ms)  SELECT COUNT(*) FROM "rates"  WHERE "rates"."rater_id" = $1 AND "rates"."dimension" = 'quality' AND "rates"."rateable_id" = 12 AND "rates"."rateable_type" = 'Bar'  [["rater_id", 1]]
11:38:51 web.1     |    (0.2ms)  SELECT COUNT(*) FROM "rates"  WHERE "rates"."rater_id" = $1 AND "rates"."dimension" = 'quality' AND "rates"."rateable_id" = 11 AND "rates"."rateable_type" = 'Bar'  [["rater_id", 1]]
11:38:51 web.1     |   Rendered routes/show.html.erb within layouts/application (8.9ms)
11:38:51 web.1     | Completed 200 OK in 142ms (Views: 130.0ms | ActiveRecord: 3.3ms)

ActiveRecord performance was from 11.9ms to 3.3ms
´´´
```
