### PR TITLE
Method name reserved by language

### DIFF
--- a/lib/generators/letsrate/letsrate_generator.rb
+++ b/lib/generators/letsrate/letsrate_generator.rb
@@ -34,7 +34,7 @@ class LetsrateGenerator < ActiveRecord::Generators::Base
   end
 
   desc "migration is creating ..."
-  def create_migration
+  def create_rates_migration
     migration_template "migration.rb", "db/migrate/create_rates.rb"
   end
 end

--- a/lib/generators/letsrate/templates/cache_migration.rb
+++ b/lib/generators/letsrate/templates/cache_migration.rb
@@ -1,19 +1,17 @@
 class CreateRatingCaches < ActiveRecord::Migration
-
-  def self.up
-      create_table :rating_caches do |t|
-        t.belongs_to :cacheable, :polymorphic => true
-        t.float :avg, :null => false
-        t.integer :qty, :null => false
-        t.string :dimension
-        t.timestamps
-      end
-
-      add_index :rating_caches, [:cacheable_id, :cacheable_type]
+  def change
+    create_table :rating_caches do |t|
+      t.belongs_to :cacheable, polymorphic: true
+      t.float :avg, null: false
+      t.integer :qty, null: false
+      t.string :dimension
+      t.timestamps
     end
 
-    def self.down
-      drop_table :rating_caches
-    end
+    add_index :rating_caches, [:cacheable_id, :cacheable_type]
+  end
 
+  def down
+    drop_table :rating_caches
+  end
 end


### PR DESCRIPTION
Simple change in the method name, as it was conflicting with reserved names of the rails 4.2.
